### PR TITLE
Update ec2.tf

### DIFF
--- a/code/module/ec2.tf
+++ b/code/module/ec2.tf
@@ -20,7 +20,7 @@ resource "aws_instance" "node" {
 # Create and assosiate an Elastic IP
 resource "aws_eip" "eip" {
   instance = aws_instance.node.id
-  vpc      = true
+  domain   = "vpc"
 }
 
 output "ec2_public_ip" {


### PR DESCRIPTION
```shell
│ Warning: Argument is deprecated
│ 
│   with aws_eip.eip,
│   on ec2.tf line 23, in resource "aws_eip" "eip":
│   23:   vpc      = true
│ 
│ use domain attribute instead
│ 
│ (and 2 more similar warnings elsewhere)
```

Clean the warning.