### PR TITLE
Update provider.tf

### DIFF
--- a/code/module/provider.tf
+++ b/code/module/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.16"
+      version = "~> 5.30.0"
     }
   }
 


### PR DESCRIPTION
```shell
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/aws: no available releases match the given constraints ~> 4.16, >= 5.30.0
```
Update version to solve error.